### PR TITLE
Use get_admin_url for edit link

### DIFF
--- a/src/plugin/inc/register-route.php
+++ b/src/plugin/inc/register-route.php
@@ -189,7 +189,7 @@ function find_blocks( $block, &$blocks, &$post, $nested_block_name = null ) {
 			'postType'        => $post->post_type,
 			'status'          => $post->post_status,
 			'post_url'        => get_permalink( $post->ID ),
-			'edit_url'        => home_url( '/wp-admin/post.php?post=' . $post->ID . '&action=edit' ),
+			'edit_url'        => get_admin_url() . 'post.php?post=' . $post->ID . '&action=edit',
 		);
 	} else {
 		$post_key = find_my_blocks_search_for_block_key( $blocks[ $block_key ]['posts'], 'id', $post->ID );


### PR DESCRIPTION
The current edit link uses `home_url` which causes a redirection loop as it generates the wrong URL for:
- multisite 
- for WordPress installed in a subfolder 

`get_admin_url` will return the proper admin URL based on the user setup.

https://developer.wordpress.org/reference/functions/get_admin_url/