### PR TITLE
Fix version in changelog

### DIFF
--- a/src/plugin/readme.txt
+++ b/src/plugin/readme.txt
@@ -42,7 +42,7 @@ Yes, this plugin will work with all blocks registered and used on your site.
 
 == Changelog ==
 
-**3.4.0**
+**3.3.1**
 
 - Uses `get_rest_url` for the fetch url.
 


### PR DESCRIPTION
The last version number in the changelog is `3.4.0` instead of `3.3.1`